### PR TITLE
Use 1.0.1i by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,5 +3,5 @@ default['ssl']['openssl']['dependencies'] = %w(
 )
 
 default['ssl']['openssl']['mirror'] = 'https://www.openssl.org/source'
-default['ssl']['openssl']['version'] = '1.0.1h'
-default['ssl']['openssl']['sha1'] = 'b2239599c8bf8f7fc48590a55205c26abe560bf8'
+default['ssl']['openssl']['version'] = '1.0.1i'
+default['ssl']['openssl']['sha1'] = '74eed314fa2c93006df8d26cd9fc630a101abd76'


### PR DESCRIPTION
Update default version to use 1.0.1i.

https://www.openssl.org/news/secadv_20140806.txt.
