### PR TITLE
Replace "verify openssl checksum" command

### DIFF
--- a/libraries/openssl.rb
+++ b/libraries/openssl.rb
@@ -36,6 +36,10 @@ module SSLHelpers
     end
 
     def tar_file_checksum
+      Digest::SHA1.hexdigest(File.read(local_tar_file))
+    end
+
+    def configured_checksum
       config['sha1']
     end
 

--- a/recipes/openssl.rb
+++ b/recipes/openssl.rb
@@ -9,14 +9,13 @@ end
 
 remote_file helper.local_tar_file do
   source helper.remote_tar_file
+  checksum helper.configured_checksum
 end
 
-execute 'verify openssl checksum' do
-  command %{[ "%s" == $(openssl sha1 %s | cut -d' ' -f2) ]} % [
-    helper.tar_file_checksum,
-    helper.local_tar_file
-  ]
-  cwd Chef::Config[:file_cache_path]
+if helper.configured_checksum != helper.tar_file_checksum
+  message = "Your configured checksum (#{helper.configured_checksum})"
+  message << " does not match the checksum for #{helper.local_tar_file} (#{helper.tar_file_checksum})."
+  raise message
 end
 
 execute 'untar openssl' do

--- a/recipes/openssl.rb
+++ b/recipes/openssl.rb
@@ -12,10 +12,14 @@ remote_file helper.local_tar_file do
   checksum helper.configured_checksum
 end
 
-if helper.configured_checksum != helper.tar_file_checksum
-  message = "Your configured checksum (#{helper.configured_checksum})"
-  message << " does not match the checksum for #{helper.local_tar_file} (#{helper.tar_file_checksum})."
-  raise message
+ruby_block 'verify openssl checksum' do
+  block do
+    if helper.configured_checksum != helper.tar_file_checksum
+      message = "Your configured checksum (#{helper.configured_checksum})"
+      message << " does not match the checksum for #{helper.local_tar_file} (#{helper.tar_file_checksum})."
+      raise message
+    end
+  end
 end
 
 execute 'untar openssl' do


### PR DESCRIPTION
Command execution is failing on Ubuntu 12.04.3 + Chef 11.12.2 with "unexpected operator". It seems that the `execute` provider isn't using an interpreter that understands square brackets. This alternative approach should make the check a little more portable.

```
192.168.2.21 Recipe: ssl::openssl
192.168.2.21   * package[openssl] action install (up to date)
192.168.2.21   * remote_file[/var/chef/cache/openssl-1.0.1i.tar.gz] action create (up to date)
192.168.2.21   * execute[verify openssl checksum] action run
192.168.2.21 ================================================================================
192.168.2.21 Error executing action `run` on resource 'execute[verify openssl checksum]'
192.168.2.21 ================================================================================
192.168.2.21
192.168.2.21
192.168.2.21 Mixlib::ShellOut::ShellCommandFailed
192.168.2.21 ------------------------------------
192.168.2.21 Expected process to exit with [0], but received '2'
192.168.2.21 ---- Begin output of [ "74eed314fa2c93006df8d26cd9fc630a101abd76" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ] ----
192.168.2.21 STDOUT:
192.168.2.21 STDERR: sh: 1: [: 74eed314fa2c93006df8d26cd9fc630a101abd76: unexpected operator
192.168.2.21 ---- End output of [ "74eed314fa2c93006df8d26cd9fc630a101abd76" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ] ----
192.168.2.21 Ran [ "74eed314fa2c93006df8d26cd9fc630a101abd76" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ] returned 2
192.168.2.21
192.168.2.21
192.168.2.21 Resource Declaration:
192.168.2.21 ---------------------
192.168.2.21 # In /var/chef/cache/cookbooks/ssl/recipes/openssl.rb
192.168.2.21
192.168.2.21  14: execute 'verify openssl checksum' do
192.168.2.21  15:   command %{[ "%s" == $(openssl sha1 %s | cut -d' ' -f2) ]} % [
192.168.2.21  16:     helper.tar_file_checksum,
192.168.2.21  17:     helper.local_tar_file
192.168.2.21  18:   ]
192.168.2.21  19:   cwd Chef::Config[:file_cache_path]
192.168.2.21  20: end
192.168.2.21  21:
192.168.2.21
192.168.2.21
192.168.2.21
192.168.2.21 Compiled Resource:
192.168.2.21 ------------------
192.168.2.21 # Declared in /var/chef/cache/cookbooks/ssl/recipes/openssl.rb:14:in `from_file'
192.168.2.21
192.168.2.21 execute("verify openssl checksum") do
192.168.2.21   action "run"
192.168.2.21   retries 0
192.168.2.21   retry_delay 2
192.168.2.21   guard_interpreter :default
192.168.2.21   command "[ \"74eed314fa2c93006df8d26cd9fc630a101abd76\" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ]"
192.168.2.21   backup 5
192.168.2.21   cwd "/var/chef/cache"
192.168.2.21   returns 0
192.168.2.21   cookbook_name "ssl"
192.168.2.21   recipe_name "openssl"
192.168.2.21 end
192.168.2.21
192.168.2.21
192.168.2.21
192.168.2.21
192.168.2.21 Running handlers:
192.168.2.21 [2014-08-18T22:29:39+00:00] ERROR: Running exception handlers
192.168.2.21 Running handlers complete
192.168.2.21
192.168.2.21 [2014-08-18T22:29:39+00:00] ERROR: Exception handlers complete
192.168.2.21 [2014-08-18T22:29:39+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
192.168.2.21 Chef Client failed. 0 resources updated in 5.701862877 seconds
192.168.2.21 [2014-08-18T22:29:39+00:00] ERROR: execute[verify openssl checksum] (ssl::openssl line 14) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '2'
192.168.2.21 ---- Begin output of [ "74eed314fa2c93006df8d26cd9fc630a101abd76" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ] ----
192.168.2.21 STDOUT:
192.168.2.21 STDERR: sh: 1: [: 74eed314fa2c93006df8d26cd9fc630a101abd76: unexpected operator
192.168.2.21 ---- End output of [ "74eed314fa2c93006df8d26cd9fc630a101abd76" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ] ----
192.168.2.21 Ran [ "74eed314fa2c93006df8d26cd9fc630a101abd76" == $(openssl sha1 /var/chef/cache/openssl-1.0.1i.tar.gz | cut -d' ' -f2) ] returned 2
192.168.2.21 [2014-08-18T22:29:39+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
